### PR TITLE
feat: create the basic main application loop

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+color-eyre = "0.6.5"
 crossterm = "0.29.0"
 ratatui = "0.29.0"
 sentry = "0.43.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,4 +4,6 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+crossterm = "0.29.0"
+ratatui = "0.29.0"
 sentry = "0.43.0"

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,0 +1,68 @@
+use color_eyre::eyre::WrapErr;
+use ratatui::crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind, read};
+use ratatui::{DefaultTerminal, Frame};
+
+#[derive(Debug)]
+pub struct App {
+    // TODO: collect text input for search
+    // query: String,
+    running: bool,
+}
+
+impl Default for App {
+    fn default() -> Self {
+        Self {
+            // TODO: collect text input for search
+            // query: String::new(),
+            running: true,
+        }
+    }
+}
+
+impl App {
+    pub fn run(&mut self, terminal: &mut DefaultTerminal) -> color_eyre::Result<()> {
+        while self.running {
+            terminal.draw(|frame| self.draw(frame))?;
+            self.process_events().wrap_err("process_events failed")?;
+        }
+        Ok(())
+    }
+
+    fn draw(&self, frame: &mut Frame) {
+        frame.render_widget("hello world", frame.area());
+    }
+
+    fn process_events(&mut self) -> color_eyre::Result<()> {
+        match read()? {
+            Event::Key(key_ev) if key_ev.kind == KeyEventKind::Press => self
+                .process_key_event(key_ev)
+                .wrap_err_with(|| format!("process_key_event failed with:\n{key_ev:#?}")),
+            _ => Ok(()),
+        }
+    }
+
+    fn process_key_event(&mut self, ev: KeyEvent) -> color_eyre::Result<()> {
+        match ev.code {
+            KeyCode::Char('q') => self.quit(),
+            //TODO: add other keybinds
+            _ => {}
+        }
+        Ok(())
+    }
+
+    fn quit(&mut self) {
+        self.running = false;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn app_quits_on_key_q() {
+        let mut app = App::default();
+        app.process_key_event(KeyCode::Char('q').into()).unwrap();
+        assert!(!app.running)
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,7 @@
-use std::io;
-
 use ratatui::crossterm::event::{Event, read};
 use ratatui::{DefaultTerminal, Frame};
 
-fn main() {
+fn main() -> color_eyre::Result<()> {
     let _guard = sentry::init((
         "https://62cf52ffca04346f14507c4a08db9b2c@o4510067097665536.ingest.de.sentry.io/4510081161756752",
         sentry::ClientOptions {
@@ -14,10 +12,11 @@ fn main() {
             ..Default::default()
         },
     ));
-
+    color_eyre::install()?;
     let mut terminal = ratatui::init();
     let res = App::default().run(&mut terminal);
     ratatui::restore();
+    res
 }
 
 #[derive(Debug)]
@@ -36,7 +35,7 @@ impl Default for App {
 }
 
 impl App {
-    pub fn run(&mut self, terminal: &mut DefaultTerminal) -> io::Result<()> {
+    pub fn run(&mut self, terminal: &mut DefaultTerminal) -> color_eyre::Result<()> {
         while self.running {
             terminal.draw(|frame| self.draw(frame))?;
             if matches!(read()?, Event::Key(_)) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,4 +9,17 @@ fn main() {
             ..Default::default()
         },
     ));
+#[derive(Debug)]
+pub struct App {
+    query: String,
+    running: bool,
+}
+
+impl Default for App {
+    fn default() -> Self {
+        Self {
+            query: String::new(),
+            running: true,
+        }
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,3 +72,15 @@ impl App {
         self.running = false;
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn app_quits_on_key_q() {
+        let mut app = App::default();
+        app.handle_key_event(KeyCode::Char('q').into()).unwrap();
+        assert!(!app.running)
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
-use color_eyre::eyre::WrapErr;
-use ratatui::crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind, read};
-use ratatui::{DefaultTerminal, Frame};
+mod app;
+
+use app::App;
 
 fn main() -> color_eyre::Result<()> {
     let _guard = sentry::init((
@@ -18,69 +18,4 @@ fn main() -> color_eyre::Result<()> {
     let result = App::default().run(&mut terminal);
     ratatui::restore();
     result
-}
-
-#[derive(Debug)]
-pub struct App {
-    // TODO: collect text input for search
-    // query: String,
-    running: bool,
-}
-
-impl Default for App {
-    fn default() -> Self {
-        Self {
-            // TODO: collect text input for search
-            // query: String::new(),
-            running: true,
-        }
-    }
-}
-
-impl App {
-    pub fn run(&mut self, terminal: &mut DefaultTerminal) -> color_eyre::Result<()> {
-        while self.running {
-            terminal.draw(|frame| self.draw(frame))?;
-            self.handle_events().wrap_err("handle_events failed")?;
-        }
-        Ok(())
-    }
-
-    fn draw(&self, frame: &mut Frame) {
-        frame.render_widget("hello world", frame.area());
-    }
-
-    fn handle_events(&mut self) -> color_eyre::Result<()> {
-        match read()? {
-            Event::Key(key_ev) if key_ev.kind == KeyEventKind::Press => self
-                .handle_key_event(key_ev)
-                .wrap_err_with(|| format!("handle_key_event failed with:\n{key_ev:#?}")),
-            _ => Ok(()),
-        }
-    }
-
-    fn handle_key_event(&mut self, ev: KeyEvent) -> color_eyre::Result<()> {
-        match ev.code {
-            KeyCode::Char('q') => self.quit(),
-            //TODO: add other keybinds
-            _ => {}
-        }
-        Ok(())
-    }
-
-    fn quit(&mut self) {
-        self.running = false;
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn app_quits_on_key_q() {
-        let mut app = App::default();
-        app.handle_key_event(KeyCode::Char('q').into()).unwrap();
-        assert!(!app.running)
-    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,8 @@
+use std::io;
+
+use ratatui::crossterm::event::{Event, read};
+use ratatui::{DefaultTerminal, Frame};
+
 fn main() {
     let _guard = sentry::init((
         "https://62cf52ffca04346f14507c4a08db9b2c@o4510067097665536.ingest.de.sentry.io/4510081161756752",
@@ -9,6 +14,12 @@ fn main() {
             ..Default::default()
         },
     ));
+
+    let mut terminal = ratatui::init();
+    let res = App::default().run(&mut terminal);
+    ratatui::restore();
+}
+
 #[derive(Debug)]
 pub struct App {
     query: String,
@@ -21,5 +32,21 @@ impl Default for App {
             query: String::new(),
             running: true,
         }
+    }
+}
+
+impl App {
+    pub fn run(&mut self, terminal: &mut DefaultTerminal) -> io::Result<()> {
+        while self.running {
+            terminal.draw(|frame| self.draw(frame))?;
+            if matches!(read()?, Event::Key(_)) {
+                self.running = false
+            }
+        }
+        Ok(())
+    }
+
+    pub fn draw(&self, frame: &mut Frame) {
+        frame.render_widget("hello world", frame.area());
     }
 }


### PR DESCRIPTION
## Description

Create a basic main application loop using ratatui.

- Added dependencies: ratatui, crossterm, color-eyre
- Initialise application and display 'hello world'
- Create the `App` module to contain key bindings and application state
- Add 1 unit test to confirm the keybinding closes the application

## Related issues

- Contributes to the milestone `Minimum Viable Product - v0.2.0`
- Contributes to #17 
- #2 
